### PR TITLE
add MIME type to script tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,9 +342,8 @@
 
             </form>
         
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
-		<script src="/semantic-ui/semantic.min.js"></script>
-        
-        <script src="/js/script.js"></script>
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js" integrity="sha256-CSXorXvZcTkaix6Yvo6HppcZGetbYMGWSFlBw8HfCJo=" crossorigin="anonymous"></script>
+        <script type="text/javascript" src="/semantic-ui/semantic.min.js"></script>        
+        <script type="text/javascript" src="/js/script.js"></script>
     </body>
 </html>


### PR DESCRIPTION
Github Pages shows an error (check console) about loading script tags and doesn't load semantic-ui